### PR TITLE
Remove protos dir from build files

### DIFF
--- a/package.json
+++ b/package.json
@@ -420,7 +420,6 @@
       "debug_log.html",
       "loading.html",
       "_locales/**",
-      "protos/*",
       "js/**",
       "libtextsecure/**",
       "ts/**/*.js",


### PR DESCRIPTION
### First time contributor checklist:

- [X] I have read the [README](https://github.com/signalapp/Signal-Desktop/blob/master/README.md) and [Contributor Guidelines](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md)
- [X] I have signed the [Contributor Licence Agreement](https://signal.org/cla/)

### Contributor checklist:

- [X] My contribution is **not** related to translations. _Please submit translation changes via our [Signal Desktop Transifex project](https://www.transifex.com/signalapp/signal-desktop/)._
- [X] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [X] My changes are [rebased](https://medium.com/free-code-camp/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [X] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [X] My changes are ready to be shipped to users

### Description

https://github.com/signalapp/Signal-Desktop/commit/570fb182d4f3bdc831e1cc1d8f98ea71ff508b7b removed the need for the `protos` directory to be present in the final package.